### PR TITLE
Fix subnet variables in Terraform configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,8 @@ jobs:
             -var="DB_USERNAME=${{ secrets.DB_USERNAME }}" \
             -var="DB_PASSWORD=${{ secrets.DB_PASSWORD }}" \
             -var="vpc_id=${{ secrets.VPC_ID }}" \
-            -var="subnets=${{ secrets.SUBNETS }}"
+            -var="subnet1=${{ secrets.SUBNET1 }}" \
+            -var="subnet2=${{ secrets.SUBNET2 }}"
       
       - name: Apply Terraform (con control de error)
         id: apply-tf
@@ -81,7 +82,8 @@ jobs:
             -var="DB_USERNAME=${{ secrets.DB_USERNAME }}" \
             -var="DB_PASSWORD=${{ secrets.DB_PASSWORD }}" \
             -var="vpc_id=${{ secrets.VPC_ID }}" \
-            -var="subnets=${{ secrets.SUBNETS }}"
+            -var="subnet1=${{ secrets.SUBNET1 }}" \
+            -var="subnet2=${{ secrets.SUBNET2 }}"
           echo $? > tf_exit_code.txt
       - name: Set refresh flag if needed
         id: set-flag

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,8 @@ module "domain_users" {
   db_username= var.DB_USERNAME
   db_password= var.DB_PASSWORD
   vpc_id     = var.vpc_id
-  subnets    = var.subnets
+  subnet1    = var.subnet1
+  subnet2    = var.subnet2
 }
 
 resource "aws_sns_topic" "asg_alerts" {

--- a/modules/microservice/main.tf
+++ b/modules/microservice/main.tf
@@ -71,7 +71,7 @@ resource "aws_lb" "alb" {
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.sg.id]
-  subnets            = var.subnets
+  subnets            = [var.subnet1, var.subnet2]
 }
 
 resource "aws_lb_target_group" "tg_create" {
@@ -204,7 +204,7 @@ resource "aws_autoscaling_group" "asg" {
   desired_capacity     = 2
   max_size             = 4
   min_size             = 2
-  vpc_zone_identifier  = var.subnets
+  vpc_zone_identifier  = [var.subnet1, var.subnet2]
   launch_template {
     id      = aws_launch_template.lt.id
     version = "$Latest"

--- a/modules/microservice/variables.tf
+++ b/modules/microservice/variables.tf
@@ -53,9 +53,14 @@ variable "vpc_id" {
   description = "VPC ID para los recursos"
 }
 
-variable "subnets" {
-  type        = list(string)
-  description = "Lista de subnets para los recursos"
+variable "subnet1" {
+  type        = string
+  description = "ID de la primera subnet"
+}
+
+variable "subnet2" {
+  type        = string
+  description = "ID de la segunda subnet"
 }
 
 variable "ami_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -45,9 +45,14 @@ variable "vpc_id" {
   description = "VPC ID para los recursos"
 }
 
-variable "subnets" {
-  type        = list(string)
-  description = "Lista de subnets para los recursos"
+variable "subnet1" {
+  type        = string
+  description = "ID de la primera subnet"
+}
+
+variable "subnet2" {
+  type        = string
+  description = "ID de la segunda subnet"
 }
 
 variable "ami_id" {


### PR DESCRIPTION
Separate subnet variables into `subnet1` and `subnet2` for improved clarity and functionality in the Terraform configuration. This change enhances the management of subnets within the infrastructure setup.